### PR TITLE
feat: process text

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 All notable changes to the NoteDx SDK will be documented in this file.
 
+## [0.1.10] - 2025-06-06
+
+### Added
+- `process_text` added as endpoint, where you can provide the transcripted text in order to generate a medical note.
+
+
 ## [0.1.9] - 2025-02-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notedx-sdk"
-version = "0.1.9"
+version = "0.1.10"
 description = "Official Python SDK for the NoteDx API - a powerful medical note generation service, fully compliant to healthcare regulations in the US and Canada."
 authors = ["Julien Martel"]
 readme = "README.md"

--- a/src/notedx_sdk/client.py
+++ b/src/notedx_sdk/client.py
@@ -78,6 +78,14 @@ class NoteDxClient:
             file_path="recording.mp3",
             template="primaryCare"
         )
+        
+        # Process text directly
+        response = client.notes.process_text(
+            text="Patient presents with chest pain for 2 hours...",
+            template="primaryCare",
+            visit_type="initialEncounter",
+            recording_type="dictation"
+        )
         ```
     
     Notes:


### PR DESCRIPTION
- adding `process_text` directly as an endpoint to allow generating a note directly from an already transcribed encounter,